### PR TITLE
Fix bug with percentage calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,12 +313,13 @@ function runmain() {
   }
 
   sim = function() {
+    let totalgames = initcount - numgames + 1;
     if (winNoSwitch()) {win1++;}
     if (winSwitch()) {win2++;}
     if (numgames == 1) {iStr3 = "Done!"}
-    iStr1 = ((win1/(initcount - numgames)) * 100).toFixed(2).toString();
-    iStr2 = ((win2/(initcount - numgames)) * 100).toFixed(2).toString();
-    count.innerHTML = "Simulating Game: " + (initcount - numgames + 1).toString();
+    iStr1 = ((win1/totalgames) * 100).toFixed(2).toString();
+    iStr2 = ((win2/totalgames) * 100).toFixed(2).toString();
+    count.innerHTML = "Simulating Game: " + totalgames.toString();
     statusD.innerHTML = "Status: " + iStr3
     noswitch.innerHTML = "Wins: " + win1.toString() + ", %Win: " + iStr1 + "%";
     outswitch.innerHTML = "Wins: " + win2.toString() + ", %Win: " + iStr2 + "%";


### PR DESCRIPTION
There is a bug with these two lines on line numbers 319 and 320:

```
    iStr1 = ((win1/(initcount - numgames)) * 100).toFixed(2).toString();
    iStr2 = ((win2/(initcount - numgames)) * 100).toFixed(2).toString();
```
The issue is that numgames value in the end of the calculation isn't zero - it's 1. So when you do initcount - numgames, it does 100 - 1 for the percentage calculation and not 100 - 0.

So if you had a calculation like this:

win1 = 50  
initgames = 100  
numgames = 1  
Your percentage value will come out as 50/99 * 100 = 50.5% and not 50% which is the expected value.

Line number 321 is further proof of this:

```
    count.innerHTML = "Simulating Game: " + (initcount - numgames + 1).toString();
```
`(initcount - numgames + 1)` refers to the current game, not `(initcount - numgames)`.